### PR TITLE
Win32 mnemonic was not properly replaced with WPF mnemonic for all la…

### DIFF
--- a/source/WPFCustomMessageBox/CustomMessageBoxWindow.xaml.cs
+++ b/source/WPFCustomMessageBox/CustomMessageBoxWindow.xaml.cs
@@ -209,26 +209,26 @@ namespace WPFCustomMessageBox
         /// </summary>
         private void SetButtonText()
         {
-            var okText = GetUserString(800).TrimStart('&');
-            var cancelText = GetUserString(801).TrimStart('&');
-            var yesText = GetUserString(805).TrimStart('&');
-            var noText = GetUserString(806).TrimStart('&');
+            var okText = GetUserString(800);
+            var cancelText = GetUserString(801);
+            var yesText = GetUserString(805);
+            var noText = GetUserString(806);
 
             if (!string.IsNullOrWhiteSpace(okText))
             {
-                Button_OK.Content = "_" + okText;
+                Button_OK.Content = okText;
             }
             if (!string.IsNullOrWhiteSpace(cancelText))
             {
-                Button_Cancel.Content = "_" + cancelText;
+                Button_Cancel.Content = cancelText;
             }
             if (!string.IsNullOrWhiteSpace(yesText))
             {
-                Button_Yes.Content = "_" + yesText;
+                Button_Yes.Content = yesText;
             }
             if (!string.IsNullOrWhiteSpace(noText))
             {
-                Button_No.Content = "_" + noText;
+                Button_No.Content = noText;
             }
         }
 
@@ -248,7 +248,18 @@ namespace WPFCustomMessageBox
             }
             var sb = new StringBuilder(1024);
             var size = LoadString(libraryHandle, stringId, sb, 1024);
-            return size > 0 ? sb.ToString() : string.Empty;
+
+            if (size > 0)
+            {
+                // Replace Win32 mnemonic with WPF mnemonic
+                sb.Replace('&', '_');
+
+                return sb.ToString();
+            }
+            else
+            {
+                return string.Empty;
+            }
         }
 
 


### PR DESCRIPTION
…nguages (some languages do not always have their mnemonic placed as the first character).

For example swedish translates "No" to "Nej" with the mnemonic placed after the letter N. See the following screenshot for an example on how the dialog looked with swedish texts before this fix (taken in the CustomMessageBoxDemo application that exists in the solution).
![messagebox](https://cloud.githubusercontent.com/assets/4549134/19935131/451b9aa8-a119-11e6-9d00-3a264598395a.png)
